### PR TITLE
Remove trailing blank space from `body_format`

### DIFF
--- a/packages/better-webhooks/src/main/resources/splunk/default/data/ui/alerts/better_webhook.html
+++ b/packages/better-webhooks/src/main/resources/splunk/default/data/ui/alerts/better_webhook.html
@@ -41,8 +41,7 @@
   "owner": $$owner$$,
   "results_link": $$results_link$$,
   "result": $$full_result$$
-} 
-            </textarea>
+}</textarea>
         </div>
         <div class="control-group">
             <div class="controls">


### PR DESCRIPTION
This PR removes the trailing blank space on the `action.better_webhook.param.body_format` textarea default.

This change will default the webhook body to a payload without trailing spaces as some JSON parsers don't support trailing spaces.

## Before

<img width="395" alt="Screenshot 2025-03-21 at 11 19 10 AM" src="https://github.com/user-attachments/assets/8ce7f3f5-4d85-4ffc-852d-338b450b1fb1" />

## After

<img width="396" alt="Screenshot 2025-03-21 at 11 20 37 AM" src="https://github.com/user-attachments/assets/a039de4a-f1a4-4f7d-ab20-819f438aad63" />