### PR TITLE
Add param defaults

### DIFF
--- a/packages/better-webhooks/src/main/resources/splunk/README/alert_actions.conf.spec
+++ b/packages/better-webhooks/src/main/resources/splunk/README/alert_actions.conf.spec
@@ -2,3 +2,12 @@
 
 param.user_agent = <string>
 * Configure value of the User-Agent header sent to the webhook receiver.
+
+param.url = <string>
+* Specified URL to send JSON payload via HTTP POST (ex., https://your.server.com/api/v1/webhook).
+
+param.body_format = <string>
+* Format of JSON POST body. For a POST body identical to the stock Splunk Webhook action, leave this at the default value.
+
+param.credential = <string>
+* The saved credential to use.

--- a/packages/better-webhooks/src/main/resources/splunk/default/alert_actions.conf
+++ b/packages/better-webhooks/src/main/resources/splunk/default/alert_actions.conf
@@ -6,3 +6,13 @@ description = Generic HTTP POST to a specified URL
 payload_format = json
 icon_path = bw.png
 param.user_agent = Splunk/$server.guid$
+param.url =
+param.body_format = {\
+  "sid": $$sid$$,\
+  "search_name": $$search_name$$,\
+  "app": $$app$$,\
+  "owner": $$owner$$,\
+  "results_link": $$results_link$$,\
+  "result": $$full_result$$\
+}
+param.credential =

--- a/packages/better-webhooks/src/main/resources/splunk/default/data/ui/alerts/better_webhook.html
+++ b/packages/better-webhooks/src/main/resources/splunk/default/data/ui/alerts/better_webhook.html
@@ -33,15 +33,7 @@
                 cols="40"
                 name="action.better_webhook.param.body_format"
                 id="body_format"
-            >
-{
-  "sid": $$sid$$,
-  "search_name": $$search_name$$,
-  "app": $$app$$,
-  "owner": $$owner$$,
-  "results_link": $$results_link$$,
-  "result": $$full_result$$
-}</textarea>
+            ></textarea>
         </div>
         <div class="control-group">
             <div class="controls">


### PR DESCRIPTION
This PR adds defaults for the `url`, `body_format`, and `credential` params. I also updated the spec with a reference to these params.

## Why?

There is a default [`body_format` in the configuration UI today](https://github.com/HurricaneLabs/BetterWebhooks/blob/49d11ea96c18f70b64a915b29b8d6bb2ce83c63f/packages/better-webhooks/src/main/resources/splunk/default/data/ui/alerts/better_webhook.html#L37-L44) but that isn't used if you create a saved search with a Better Webhooks trigger action via the Splunk API. While this is fine for `url` and `credential`, having an empty `body_format` causes the following exception when attempting to send a webhook:

<img width="1293" alt="Screenshot 2025-05-23 at 12 06 55 PM" src="https://github.com/user-attachments/assets/8d4efe4e-a5ff-42dd-b4d4-aa29a1b182d9" />

Moving the default to `default/alert_actions.conf` makes it the default value for alerts created via the Web UI and the Splunk API. :tada:

## Before

An alert (saved search) created via the API has no default `action.better_webhook.param.body_format`:

<img width="996" alt="Screenshot 2025-05-23 at 12 01 26 PM" src="https://github.com/user-attachments/assets/e1056382-dcde-48c6-b075-bde52b8e2a8c" />

## After

With these changes, alerts created via the API (and web UI) now always have a default (or user specified) value for all params:

<img width="996" alt="Screenshot 2025-05-23 at 12 08 34 PM" src="https://github.com/user-attachments/assets/c51b0f31-3a52-4a60-8cdc-e7cba9bb2669" />

> [!NOTE]
> The defaults in `alert_actions.conf` also populate the web UI. This means creating/saving an alert via the web will _set a body_format_ (equal to the default) instead of using the default.
>
> This matches the behavior today but is worth noting as updating the default value in the future won't change alerts created this way.
>
> <img width="702" alt="Screenshot 2025-05-23 at 12 45 49 PM" src="https://github.com/user-attachments/assets/740cfd96-f4c5-4469-a221-81e467de6159" />